### PR TITLE
T7214 - Adição do Módulo de Informação personalizada no CRM

### DIFF
--- a/base_custom_info/models/custom_info_value.py
+++ b/base_custom_info/models/custom_info_value.py
@@ -12,9 +12,10 @@ class CustomInfoValue(models.Model):
     _rec_name = 'value'
     _order = ("model, res_id, category_sequence, category_id, "
               "property_sequence, property_id")
+
     _sql_constraints = [
         ("property_owner",
-         "UNIQUE (property_id, model, res_id)",
+         "UNIQUE (property_id, model, res_id, value_id)",
          "Another property with that name exists for that resource."),
     ]
 

--- a/base_custom_info/views/custom_info_value_view.xml
+++ b/base_custom_info/views/custom_info_value_view.xml
@@ -3,24 +3,23 @@
      Copyright 2017 Pedro M. Baeza <pedro.baeza@tecnativa.com>
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl). -->
 <odoo>
-
     <record id="custom_info_value_tree" model="ir.ui.view">
         <field name="model">custom.info.value</field>
         <field name="arch" type="xml">
-            <tree string="Custom Property Values" create="0" delete="0">
-                <field name="owner_id" />
-                <field name="property_id" force_save="1"/>
-                <field name="category_id" force_save="1"/>
+            <tree string="Custom Property Values" create="1" delete="1">
+                <field name="owner_id"/>
+                <field name="property_id" force_save="1" options="{'no_create': True, 'no_open': True}"/>
+                <field name="category_id" force_save="1" options="{'no_create': True, 'no_open': True}"/>
                 <field name="required" invisible="1"/>
                 <field name="field_type" invisible="1"/>
                 <field name="value"
-                    attrs="{'invisible': [('field_type', '=', 'id')], 'required': [('required', '=', True), ('field_type', '!=', 'id')]}"
-                />
+                       attrs="{'invisible': [('field_type', '=', 'id')],
+                               'required': [('required', '=', True), ('field_type', '!=', 'id')]}"/>
                 <field name="value_id"
-                    force_save="1"
-                    options="{'no_create': True, 'no_open': True}"
-                    attrs="{'invisible': [('field_type', '!=', 'id')], 'required': [('required', '=', True), ('field_type', '=', 'id')]}"
-                />
+                       force_save="1"
+                       options="{'no_create': True, 'no_open': True}"
+                       attrs="{'invisible': [('field_type', '!=', 'id')],
+                               'required': [('required', '=', True), ('field_type', '=', 'id')]}"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
# Descrição

Adiciona Novos Recursos módulo 'base_custom_info'

- Adiciona Posibilidade de Incluir ou Excluir Linhas 'custom.info.value'.
- Limita a Criação de Novos Valores a Partir de Inclusão dos campos personalizados.

# Informações adicionais

Dados da tarefa: [T7214 ](link)

PR(s) relacionado(s) (se houver): [1195](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1195)
