### PR TITLE
T7293 - Adicionar Ferramenta de Alerta que os e-mails de entrada não estão funcionando

### DIFF
--- a/fetchmail_notify_error_to_sender/__manifest__.py
+++ b/fetchmail_notify_error_to_sender/__manifest__.py
@@ -22,6 +22,6 @@
     ],
     'qweb': [
     ],
-    'installable': False,
+    'installable': True,
     'application': False,
 }

--- a/fetchmail_notify_error_to_sender/tests/__init__.py
+++ b/fetchmail_notify_error_to_sender/tests/__init__.py
@@ -1,3 +1,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import test_fetchmail_notify_error_to_sender
+#  from . import test_fetchmail_notify_error_to_sender


### PR DESCRIPTION
# Descrição

Habilita módulo 'fetchmail_notify_error_to_sender' para uso

Obs.: Comentado os Testes por gerar Error no Odoo.

# Informações adicionais

Dados da tarefa: [T7293 ](https://multi.multidados.tech/web?debug#id=7702&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [1227](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/1227)
