### PR TITLE
T8742 - Erro de assinatura de XML no Python 3.10

### DIFF
--- a/excel_import_export/models/xlsx_export.py
+++ b/excel_import_export/models/xlsx_export.py
@@ -253,7 +253,7 @@ class XLSXExport(models.AbstractModel):
         content = BytesIO()
         wb.save(content)
         content.seek(0)  # Set index to 0, and start reading
-        out_file = base64.encodestring(content.read())
+        out_file = base64.encodebytes(content.read())
         if record and 'name' in record and record.name:
             out_name = record.name.replace(' ', '').replace('/', '')
         else:


### PR DESCRIPTION
# Descrição

Substitui encodestring por decodebytes

# Informações adicionais

Dados da tarefa: [T8742](https://multi.multidados.tech/web#id=9151&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)
